### PR TITLE
Adding event emission in external registration contract to the standard

### DIFF
--- a/EIPS/eip-4824.md
+++ b/EIPS/eip-4824.md
@@ -51,7 +51,7 @@ The DAO JSON-LD Schema mentioned above:
 }
 ```
 
-A DAO MAY inherit the above interface above or it MAY create an external registration contract that is compliant with this EIP. The external registration contract MUST store the DAO’s primary address. The external registration contract SHOULD emit an event when creating the new daoURI for efficient network indexing.
+A DAO MAY inherit the above interface above or it MAY create an external registration contract that is compliant with this EIP. The external registration contract MUST store the DAO’s primary address. The external registration contract MUST emit an event `NewURI(daoURI_)` when setting the new daoURI for efficient network indexing.
 
 ```solidity
 pragma solidity ^0.8.1;
@@ -90,7 +90,7 @@ contract EIP4824Registration is EIP4824 {
 }
 ```
 
-If a DAO uses an external registration contract, the DAO SHOULD use a common registration factory contract to enable efficient network indexing.
+If a DAO uses an external registration contract, the DAO SHOULD use a common registration factory contract to enable efficient network indexing. The common registration factory contract MUST emit an event `NewRegistration(msg.sender, daoURI_, address(reg))` when a new DAO is initialized.
 
 ```solidity
 pragma solidity ^0.8.1;

--- a/EIPS/eip-4824.md
+++ b/EIPS/eip-4824.md
@@ -51,7 +51,7 @@ The DAO JSON-LD Schema mentioned above:
 }
 ```
 
-A DAO MAY inherit the above interface above or it MAY create an external registration contract that is compliant with this EIP. The external registration contract MUST store the DAO’s primary address.
+A DAO MAY inherit the above interface above or it MAY create an external registration contract that is compliant with this EIP. The external registration contract MUST store the DAO’s primary address. The external registration contract SHOULD emit an event when creating the new daoURI for efficient network indexing.
 
 ```solidity
 pragma solidity ^0.8.1;


### PR DESCRIPTION
After discussions with @thelastjosh, in line with https://github.com/metagov/daostar/issues/54#issuecomment-1490575877 to maintain a registry of DAOs adhering to the standard, a line specifically requiring DAOs to emit events in their external registration contract has been added.

Here's the line for reference:

> The external registration contract SHOULD emit an event when creating the new daoURI for efficient network indexing.