### PR TITLE
Add Aragon OSx proposal statuses

### DIFF
--- a/EIPS/eip-4824.md
+++ b/EIPS/eip-4824.md
@@ -264,7 +264,7 @@ Proposals have become a standard way for the members of a DAO to trigger on-chai
 
 | Project | Proposal Statuses |
 | --- | --- |
-| Aragon | Not specified |
+| Aragon | [‘Drafted‘, ‘Pending‘, ‘Active‘, ‘Challenged‘, ‘Vetoed‘, ‘Rejected‘, ‘Accepted‘, ‘Queued‘, ‘Expired‘, ‘Executed‘, ‘PartiallyExecuted‘, ‘Failed‘] |
 | Colony | [‘Null’, ‘Staking’, ‘Submit’, ‘Reveal’, ‘Closed’, ‘Finalizable’, ‘Finalized’, ‘Failed’] |
 | Compound | [‘Pending’, ‘Active’, ‘Canceled’, ‘Defeated’, ‘Succeeded’, ‘Queued’, ‘Expired’, ‘Executed’] |
 | DAOstack/ Alchemy | [‘None’, ‘ExpiredInQueue’, ‘Executed’, ‘Queued’, ‘PreBoosted’, ‘Boosted’, ‘QuietEndingPeriod’] |


### PR DESCRIPTION
<!--When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.-->

This PR adds the proposal statuses of Aragon OSx.